### PR TITLE
fix: output text not include command name

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -193,7 +193,7 @@ export function defineVariation<
               })
             }
           } else {
-            return session?.text('wordle.messages.no-input')
+            return session?.text('wordle.messages.no-input', [command.name])
           }
         } else {
           // start a new game


### PR DESCRIPTION
The current text to notify user that the game has been begun and the user didn't include their answers into the command invoke is lacking the command name.

Current:

```text
游戏正在进行，请使用 <答案> 提交你猜测的结果。
```

Expected:

```text
游戏正在进行，请使用 /wordle <答案> 提交你猜测的结果。
```